### PR TITLE
Changed the key for articles

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,7 +95,7 @@ def first_article():
     article = get_first_article(get_db(), app)
     if article is None:
         return Response("No articles found", 404)
-    html = download_article(DLF_PREFIX + article["href"])
+    html = download_article(DLF_PREFIX + article["key"])
     parsed = parse_article(html)
     update_article_contents(get_db(), parsed)
     return parsed

--- a/app/db_helper/__init__.py
+++ b/app/db_helper/__init__.py
@@ -64,12 +64,11 @@ def _article_from_db_result(row: tuple):
         "teaserText": row[3],
         "date": row[4],
         "localeDate": row[5],
-        "href": row[6],
-        "kicker": row[7],
-        "description": row[8],
-        "content": row[9],
-        "category": row[10],
-        "status": row[11],
+        "kicker": row[6],
+        "description": row[7],
+        "content": row[8],
+        "category": row[9],
+        "status": row[10],
     }
 
 
@@ -116,10 +115,6 @@ def insert_articles(db: Connection, articles: list[dict]):
     cursor = db.cursor()
     non_articles = []
     for article in articles:
-        href = article["href"]
-        if not href.startswith(DLF_PREFIX):
-            non_articles.append(href)
-        href = href[len(DLF_PREFIX) :]
         key = article["key"]
         title = article["title"]
         teaser_headline = article["teaserHeadline"]
@@ -127,7 +122,7 @@ def insert_articles(db: Connection, articles: list[dict]):
         date = article["date"]
         locale_date = article["localeDate"]
 
-        elements = (key, title, teaser_headline, teaser_text, date, locale_date, href)
+        elements = (key, title, teaser_headline, teaser_text, date, locale_date)
 
         cursor.execute(INSERT_ARTICLES, elements)
     db.commit()
@@ -167,3 +162,4 @@ def get_print_articles(db: Connection) -> list:
 def mark_bullets_as_printed(db: Connection):
     db.cursor().execute(MARK_BULLETS_PRINTED)
     db.commit()
+

--- a/app/db_helper/queries.py
+++ b/app/db_helper/queries.py
@@ -6,9 +6,9 @@ COUNT_CATEGORIES = """SELECT COUNT(DISTINCT category) FROM articles WHERE status
 
 INSERT_ARTICLES = """
 INSERT OR IGNORE INTO `articles`
-    (key, title, teaserHeadline, teaserText, date, localeDate, href)
+    (key, title, teaserHeadline, teaserText, date, localeDate)
 VALUES
-    (  ?,     ?,              ?,          ?,    ?,          ?,    ?)
+    (  ?,     ?,              ?,          ?,    ?,          ?)
 """
 
 FIRST_ARTICLE = """

--- a/app/dlf.py
+++ b/app/dlf.py
@@ -29,9 +29,7 @@ def download_wochenrueckblick() -> str:
 
 
 def _parse_partial_article(script: Tag) -> dict | None:
-    j = json.loads(script["data-json"])
-    key = j["key"]
-    j = j["value"]
+    j = json.loads(script["data-json"])["value"]
 
     if "__typename" not in j:
         if "data" in j and "newsByWeek" in j["data"]:
@@ -45,14 +43,15 @@ def _parse_partial_article(script: Tag) -> dict | None:
 
     if j["__typename"] == "Teaser" and j["path"] not in _NON_ARTICLES_URLS:
         _LOGGER.info(f"  -> Found Article '{j['title']}'")
+        if not j["path"].startswith(PREFIX):
+            return None
         return {
-            "key": key,
+            "key": j["path"][len(PREFIX):],
             "title": j["title"],
             "teaserHeadline": j["teaserHeadline"],
             "teaserText": j["teasertext"],
             "date": j["firstPublicationDate"],
             "localeDate": j["dateLocalizedFormatted"],
-            "href": j["path"],
         }
     else:
         _LOGGER.debug(f"Not a Teaser/News Article: {j}")

--- a/app/schema.sql
+++ b/app/schema.sql
@@ -1,12 +1,11 @@
 CREATE TABLE IF NOT EXISTS 'articles' (
     -- Data extracted from wochenuberblick
-    key varchar(63) UNIQUE NOT NULL PRIMARY KEY,
+    key varchar(255) UNIQUE NOT NULL PRIMARY KEY,
     title text NOT NULL,
     teaserHeadline text NOT NULL,
     teaserText text NOT NULL,
     date timestamp NOT NULL,
     localeDate text NOT NULL,
-    href text NOT NULL,
 
     -- Data from the full article
     kicker text DEFAULT NULL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "aktuelle5minuten"
-version = "1.0.0"
-description = ""
+version = "1.0.1"
+description = "Semi-automatische PDF-Erstellung mit den News der letzten Woche vom Deutschlandfunk "
 authors = ["MaFeLP <mafelp@proton.me>"]
 readme = "README.md"
 


### PR DESCRIPTION
This is, so the same article is only tindered once, not multiple times!

This hopefully also fixes a bug, where manual database intervention was needed, as the article was promoted/demoted but still present in the tinder DB.

> [!CAUTION]
> A Database migration is required for this update to complete!
> The easiest way is:
> 1. Stop the running docker container
> 2. Remove the `db.sqlite3` file. Watch out: All data is lost
> 3. Update (`docker pull ghcr.io/MaFeLP/aktuelle5minuten:main`) the docker container
> 4. Recreate and restart the docker container
> 5. Access the index page.